### PR TITLE
Add Wit AI to NLP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ APIs
 - [Open Calais](http://www.opencalais.com/opencalais-api/) - Good entity extraction, no sentiment analysis.
 - [Semantria](https://www.lexalytics.com/) - SAAS API based on Lexalytics engine. #Paid
 - [Datum Box](http://www.datumbox.com/machine-learning-api/) - Datumbox offers a powerful open-source Machine Learning Framework written in Java. ![Open Source](https://raw.githubusercontent.com/Abhishaker17/Awesome-APIs/master/opensource.png?token=AH5Y2imVR5ukgG9533IEqXnP-RJWxVJQks5W4PuNwA%3D%3D "Open Source")
+- [Wit AI](https://wit.ai/) - Provides an intent-based NLP API to easily build text and audio based chat bots. ![Open Source](https://raw.githubusercontent.com/Abhishaker17/Awesome-APIs/master/opensource.png?token=AH5Y2imVR5ukgG9533IEqXnP-RJWxVJQks5W4PuNwA%3D%3D "Open Source")
 
 ### Placeholder Images 
 


### PR DESCRIPTION
Wit AI is an NLP API that allows you to train an NLP algorithm by using something called as intents that can be extracted from text or audio. It can then extract the data you desire, in the form of entities, and send it back.

For example:
If I want to create a bot to convert currencies, my intent will be "currency". You train Wit by giving it multiple statements with your intent, like:
_"Can you convert **30** **INR** to **USD**?"_
_"How much is **10** **USD** in **GBP**"_
...

You also teach it what your entities are, (which are marked in bold), which you can assign names to, so in the first example

- 30 would be "amount",
- INR would be "from",
- USD would be "to"

Once you train it with enough data, it can understand intents, and extract the entities from sentences for you.

It provides a rather intuitive way of building chat bots, since it also has the ability to retain context, and allows you to use it to create really powerful bots.

All you need is an API Developer's key to get started!