### PR TITLE
Update references from 'Twitter' to 'X (formerly Twitter)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**TikTok**](https://developers.tiktok.com/) | TikTok Display API allows you to display TikTok creator's videos and their profile information and many more features. | **N/A** |
 | [**Trash Nothing**](https://trashnothing.com/developer) | Build apps on top of one of the largest freecycling and reuse communities with millions of people giving away thousands of free items every day. | **N/A** |
 | [**Twitch**](https://dev.twitch.tv/docs) | The Twitch API enables you to develop your own applications using the rich feature set that Twitch provides. | **N/A** |
-| [**Twitter**](https://developer.twitter.com/) | Enables an app to interact with many of Twitter’s functions. | **N/A** |
+| [**Twitter**](https://developer.twitter.com/) | Enables an app to interact with many of X's (formerly Twitter) functions. | **N/A** |
 | [**Tumblr**](https://www.tumblr.com/docs/en/api/v2) | Create new ways to use Tumblr with access to content, likes, followers, and drafts. | **N/A** |
 | [**Vimeo**](https://developer.vimeo.com/) | Access to Vimeo’s API. | **N/A** | 
 | [**Viber**](https://developers.viber.com/docs/api/) | With Viber’s APIs, you can create unique experiences for users at scale. | **N/A** |


### PR DESCRIPTION
This pull request updates reference from "Twitter" to "X (formerly Twitter)" to reflect the recent rebranding. This change ensures that the terminology used in the repository is accurate and up-to-date.