### PR TITLE
Add Vedika API to Science section

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Open Science Framework**](https://osf.io/y9jdt/wiki/home/) | A free, open source workflow/project management system for storing, collaborating on, and sharing research across the scholarly life cycle. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") |
 | [**Open Access Button**](https://openaccessbutton.org/api) | Free, legal research articles delivered instantly or automatically requested from authors. | **N/A** |
 | [**SHARE**](http://share-research.readthedocs.io/en/latest/) | A free, open dataset of scholarly research activity across the scholarly lifecycle. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") |
+| [**Vedika**](https://vedika.io) | AI-powered Vedic astrology API with 108+ endpoints for birth charts, horoscopes, and panchang. | 💸 |
 
 [⬆ Back to Table of Contents](#table-of-contents)
 ### Screenshots


### PR DESCRIPTION
Adding [Vedika API](https://vedika.io) to the Science section.

**Vedika API** provides:
- 108+ REST API endpoints for Vedic astrology
- Birth charts (Kundali) generation
- Daily/weekly/monthly horoscopes
- Panchang (Hindu calendar) data
- AI-powered astrology chatbot
- Free sandbox for testing