### PR TITLE
Add Stock Sentiment to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Peru**](https://estadisticas.bcrp.gob.pe/estadisticas/series/ayuda/api) | Variety of data in [XLSX](https://en.wikipedia.org/wiki/Microsoft_Excel#File_formats) format. | **N/A** |
 | [**Poland**](https://api.nbp.pl) | Currency exchange rates and gold prices in the [XML](https://en.wikipedia.org/wiki/XML) and [JSON](https://en.wikipedia.org/wiki/JSON) formats. | **N/A** |
 | [**Russian Federation**](https://www.cbr.ru/development/) | History of exchange rates via REST [XML](https://en.wikipedia.org/wiki/XML) and far more macroeconomical info via SOAP. | **N/A** |
+| [**Stock Sentiment**](https://api.adanos.org/docs) | Reddit & X/Twitter sentiment analysis for stocks with buzz scores | **N/A** |
 | [**Switzerland**](https://data.snb.ch/en) | Rich variety of data in [XLS](https://en.wikipedia.org/wiki/Microsoft_Excel#File_formats) and [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) formats. | **N/A** |
 | [**Ukraine**](https://bank.gov.ua/control/en/publish/article?art_id=25365630) | Exchange rates and bond placements in [JSON](https://en.wikipedia.org/wiki/JSON) and [XML](https://en.wikipedia.org/wiki/XML) formats. | **N/A** |
 | [**Portfolio Optimizer**](https://portfoliooptimizer.io/) | API for investment portfolio optimization. | **N/A** |

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Peru**](https://estadisticas.bcrp.gob.pe/estadisticas/series/ayuda/api) | Variety of data in [XLSX](https://en.wikipedia.org/wiki/Microsoft_Excel#File_formats) format. | **N/A** |
 | [**Poland**](https://api.nbp.pl) | Currency exchange rates and gold prices in the [XML](https://en.wikipedia.org/wiki/XML) and [JSON](https://en.wikipedia.org/wiki/JSON) formats. | **N/A** |
 | [**Russian Federation**](https://www.cbr.ru/development/) | History of exchange rates via REST [XML](https://en.wikipedia.org/wiki/XML) and far more macroeconomical info via SOAP. | **N/A** |
-| [**Stock Sentiment**](https://api.adanos.org/docs) | Reddit & X/Twitter sentiment analysis for stocks with buzz scores | **N/A** |
+| [**Finance Sentiment API**](https://api.adanos.org/docs) | Reddit, News, Polymarket & X/Twitter sentiment analysis for stocks and crypto | **N/A** |
 | [**Switzerland**](https://data.snb.ch/en) | Rich variety of data in [XLS](https://en.wikipedia.org/wiki/Microsoft_Excel#File_formats) and [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) formats. | **N/A** |
 | [**Ukraine**](https://bank.gov.ua/control/en/publish/article?art_id=25365630) | Exchange rates and bond placements in [JSON](https://en.wikipedia.org/wiki/JSON) and [XML](https://en.wikipedia.org/wiki/XML) formats. | **N/A** |
 | [**Portfolio Optimizer**](https://portfoliooptimizer.io/) | API for investment portfolio optimization. | **N/A** |


### PR DESCRIPTION
Adding **Stock Sentiment** API to the Finance category.

Provides Reddit & X/Twitter sentiment analysis for stocks with buzz scores.

## Checklist
- [x] Searched previous suggestions
- [x] Individual pull request for this suggestion
- [x] Title is capitalized
- [x] Description is short and simple
- [x] APIs sorted alphabetically (between Russian Federation and Switzerland)
- [x] Links to documentation page