### PR TITLE
Add SnapAPI to Screenshots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,6 +689,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**ApiFlash**](https://apiflash.com/) | Chrome based screenshot API to convert URLs to images. | **N/A** |
 | [**SavePage.io**](https://docs.savepage.io) | A free, RESTful API used to screenshot any desktop or mobile website with the real Chrome browser. | 💸 |
 | [**ScreenshotAPI.net**](https://screenshotapi.net) | Use one simple API call to generate screenshots of any website. | **N/A** |
+| [**SnapAPI**](https://snapapi.pics) | Screenshot, video recording, PDF generation, and web data extraction API. Free tier included. | **N/A** |
 
 [⬆ Back to Table of Contents](#table-of-contents)
 ### Social Media


### PR DESCRIPTION
Adding SnapAPI (https://snapapi.pics) — screenshot, video recording, PDF generation, and web data extraction API with a free tier.