### PR TITLE
🤖🤖🤖 Add LinkShrink to URL Shorteners section

### DIFF
--- a/README.md
+++ b/README.md
@@ -786,6 +786,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Bitly**](http://dev.bitly.com/links.html) | Access to Bitly’s API. | **N/A** |
 | [**GoTiny**](https://github.com/robvanbakel/gotiny-api) | Lightweight and easy to implement URL shortener. Supports custom links and offers JavaScript SDK. | **N/A** |
 | [**Is.gd**](https://is.gd/developers.php) | Simple URL shortener. Supports custom short link ending. | **N/A** |
+| [**LinkShrink**](https://linkshrink.dev) | Free privacy-first URL shortener API with analytics, UTM support, and CSV export. No API key required. | **N/A** |
 | [**ShrtURI**](https://shrturi.com/docs) | URL shortening API for creating short URLs from long URLs. | **N/A** |
 | [**Tiny.cc**](https://tiny.cc/api-docs) | Easy-to-use URL shortener. Supports custom short link ending. | **N/A** |
 | [**Tiny.UID**](https://tinyuid.com/docs) | API for shortening long URLs. | **N/A** |


### PR DESCRIPTION
## Summary

Adds [LinkShrink](https://linkshrink.dev) to the `### URL Shorteners` section.

- Free privacy-first URL shortener API with analytics, UTM support, and CSV export.
- No API key required.
- Inserted in alphabetical order.

## Checklist

- [x] Entry follows existing format
- [x] Alphabetical order maintained
- [x] Description ends with a period
- [x] No API key required → marked **N/A**