### PR TITLE
🤖🤖🤖 Add OGForge to Design section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | --- | ----------- | ---- |
 | [**Dribbble**](http://developer.dribbble.com/) | Dribbble is a community of designers answering that question each day. | **N/A** |
 | [**Icon Horse**](https://icon.horse/usage) | Get the favicon logo for any web address, customizable and complete with a fallback if it fails. | **N/A** |
+| [**OGForge**](https://ogforge.dev) | Free Open Graph image generator API with themes, icons, and custom layouts. No API key required. | **N/A** |
 | [**Pexels**](https://www.pexels.com/api/) | Pexels provides high quality and completely free stock photos licensed under the Creative Commons Zero (CC0) license. | **N/A** |
 | [**PHP-Noise**](https://php-noise.com/) | Noise background image generator api with various parameters. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") |
 


### PR DESCRIPTION
## Summary

Adds [OGForge](https://ogforge.dev) to the `### Design` section.

- Free Open Graph image generator API with themes, icons, and custom layouts.
- No API key required.
- Inserted in alphabetical order (between Icon Horse and Pexels).

## Checklist

- [x] Entry follows existing format
- [x] Alphabetical order maintained
- [x] Description ends with a period
- [x] No API key required → marked **N/A**