### PR TITLE
🤖🤖🤖 Add LinkMeta to Content section

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Bible**](https://bible-api.com/) | JSON API for public domain and open bible translations. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") | 
 | [**Fruits API**](https://github.com/Franqsanz/fruits-api) | API GraphQL with information on fruit trees of the world. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") | 
 | [**Jokes**](https://jokes.one/api/joke/) | Full featured Jokes API  | 💸 |
+| [**LinkMeta**](https://linkmeta.dev) | Free URL metadata extraction API for Open Graph, Twitter Cards, favicons, and JSON-LD. No API key required. | **N/A** |
 | [**Perfect Tense API**](https://www.perfecttense.com/developers) | The Perfect Tense API is the only spelling and grammar checking API that uses artificial intelligence to correct all of your text automatically in one call. | 💸 |
 | [**qKast Channel Content**](https://github.com/egfx/qKast) | Access live content collections sourced from any page around the web. | **N/A** |
 | [**Random Data Generator**](https://randommer.io/randommer-api) | API Generator for telephones, text, numbers, passwords, names, social security numbers, and cards. | 💸 |


### PR DESCRIPTION
## Summary

Adds [LinkMeta](https://linkmeta.dev) to the `### Content` section.

- Free URL metadata extraction API for Open Graph, Twitter Cards, favicons, and JSON-LD.
- No API key required.
- Inserted in alphabetical order (between Jokes and Perfect Tense API).

## Checklist

- [x] Entry follows existing format
- [x] Alphabetical order maintained
- [x] Description ends with a period
- [x] No API key required → marked **N/A**