### PR TITLE
Add PDFSpark to File Storage and Manipulation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Filestack**](https://filestack.com/docs/) | API for image and file manipulation, 250 uploads and 500 uploads per month for free, free CDN, HTML widget. | **N/A** |
 | [**Microsoft Graph**](https://graph.microsoft.io/en-us/docs/api-reference/v1.0/resources/onedrive) | API for accessing stored files and photos for personal and enterprise users with high resolution thumbnails and Microsoft Office APIs. | **N/A** |
 | [**PDF Blocks**](https://www.pdfblocks.com/docs/api/getting-started) | API for working with PDF documents (merge, add password, watermark, and more). Well documented, easy to use. 14-day free trial. | 💸 |
+| [**PDFSpark**](https://pdfspark.dev) | Free HTML and URL to PDF conversion API. Convert web pages and raw HTML to high-quality PDF documents. | **N/A** |
 | [**SignNow API – eSign API by airSlate**](https://docs.signnow.com/docs/signnow/welcome) | Embed branded eSignature workflows in your app and quickly customize them to your user needs. | 💸 |
 | [**Smash**](https://api.fromsmash.com/) | Smash API & SDK to upload large files on websites, mobile apps, SaaS solutions and custom workflows. | 💸 |
 | [**Vector Express**](https://github.com/smidyo/vectorexpress-api) | API for converting, processing and analyzing vector files.| **N/A** |


### PR DESCRIPTION
## Summary

Adds [PDFSpark](https://pdfspark.dev) to the `### File Storage and Manipulation` section.

- Free HTML and URL to PDF conversion API for converting web pages and raw HTML to high-quality PDF documents.
- No API key required.
- Inserted in alphabetical order.

## Checklist

- [x] Entry follows existing format
- [x] Alphabetical order maintained
- [x] Description ends with a period
- [x] No API key required → marked **N/A**