### PR TITLE
Add PageShot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | API | Description | Open/Trial |
 | --- | ----------- | ---- |
 | [**ApiFlash**](https://apiflash.com/) | Chrome based screenshot API to convert URLs to images. | **N/A** |
+| [**PageShot**](https://pageshot.site/docs) | Capture full-page screenshots of any webpage with custom viewport and format options. | **N/A** |
 | [**SavePage.io**](https://docs.savepage.io) | A free, RESTful API used to screenshot any desktop or mobile website with the real Chrome browser. | 💸 |
 | [**ScreenshotAPI.net**](https://screenshotapi.net) | Use one simple API call to generate screenshots of any website. | **N/A** |
 


### PR DESCRIPTION
Adds [PageShot](https://pageshot.site/docs) to the **Screenshots** section.

Free API to capture full-page screenshots of any webpage. No authentication required.

- [x] Individual pull request
- [x] Description ends with a period
- [x] Alphabetical order maintained
- [x] Links to documentation page