### PR TITLE
Add PageShot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | API | Description | Open/Trial |
 | --- | ----------- | ---- |
 | [**ApiFlash**](https://apiflash.com/) | Chrome based screenshot API to convert URLs to images. | **N/A** |
+| [**PageShot**](https://pageshot.site) | Free screenshot and web page capture API. Generate full-page screenshots, element captures, and PDF exports from any URL. | **N/A** |
 | [**SavePage.io**](https://docs.savepage.io) | A free, RESTful API used to screenshot any desktop or mobile website with the real Chrome browser. | 💸 |
 | [**ScreenshotAPI.net**](https://screenshotapi.net) | Use one simple API call to generate screenshots of any website. | **N/A** |
 


### PR DESCRIPTION
Adds [PageShot](https://pageshot.site) to the **Screenshots** section.

PageShot is a free screenshot and web page capture API. Generate full-page screenshots, element captures, and PDF exports from any URL. No API key required. HTTPS. CORS enabled.

- API documentation: https://pageshot.site
- Free forever, no authentication needed