### PR TITLE
Add TCG Price Lookup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Studio Ghibli**](https://ghibliapi.vercel.app/) | Resources from Studio Ghibli films. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") |
 | [**StockX API**](https://stockx.vlour.me/) | Unofficial API listing 150k+ sneakers and fashion products with daily-updated prices. | **N/A** |
 | [**TCGdex**](https://www.tcgdex.dev/) | A Multilanguage Pokémon TCG Database with Cards Pictures and most of the information contained on the cards. | ![Open Source](https://raw.githubusercontent.com/abhishekbanthia/Public-APIs/master/opensource.png "Open Source") |
+| [**TCG Price Lookup**](https://tcgpricelookup.com/tcg-api) | Live trading card prices across Pokemon, MTG, Yu-Gi-Oh, Lorcana, One Piece, Star Wars Unlimited, and Flesh and Blood. TCGPlayer + eBay + PSA/BGS/CGC. | **N/A** |
 
 [⬆ Back to Table of Contents](#table-of-contents)
 ### Events


### PR DESCRIPTION
Adds **TCG Price Lookup** — live trading card prices across 8 TCGs (Pokemon, MTG, Yu-Gi-Oh, Lorcana, One Piece, SWU, FaB) with TCGPlayer market data, eBay sold averages, and PSA/BGS/CGC graded prices.

Free tier: 10,000 req/month. https://tcgpricelookup.com/tcg-api

Placed alphabetically after TCGdex in the Entertainment section.