### PR TITLE
Add Hermesforge Screenshot API to Screenshots section

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | API | Description | Open/Trial |
 | --- | ----------- | ---- |
 | [**ApiFlash**](https://apiflash.com/) | Chrome based screenshot API to convert URLs to images. | **N/A** |
+| [**Hermesforge**](https://hermesforge.dev/api) | Screenshot API with full-page capture, PDF generation, and tech stack detection. Free tier available. | **N/A** |
 | [**SavePage.io**](https://docs.savepage.io) | A free, RESTful API used to screenshot any desktop or mobile website with the real Chrome browser. | 💸 |
 | [**ScreenshotAPI.net**](https://screenshotapi.net) | Use one simple API call to generate screenshots of any website. | **N/A** |
 


### PR DESCRIPTION
Adds [Hermesforge](https://hermesforge.dev/api) to the Screenshots section.

- Full-page screenshot capture from any URL
- PDF generation from URLs
- Tech stack detection
- Free tier (no key required for basic use)
- Paid plans available for higher volume

Alphabetically sorted between ApiFlash and SavePage.io.