### PR TITLE
Add PixelVault to File Storage and Manipulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ This is an attempt to categorise different APIs scoured from the web which make 
 | [**Filestack**](https://filestack.com/docs/) | API for image and file manipulation, 250 uploads and 500 uploads per month for free, free CDN, HTML widget. | **N/A** |
 | [**Microsoft Graph**](https://graph.microsoft.io/en-us/docs/api-reference/v1.0/resources/onedrive) | API for accessing stored files and photos for personal and enterprise users with high resolution thumbnails and Microsoft Office APIs. | **N/A** |
 | [**PDF Blocks**](https://www.pdfblocks.com/docs/api/getting-started) | API for working with PDF documents (merge, add password, watermark, and more). Well documented, easy to use. 14-day free trial. | 💸 |
+| [**PixelVault**](https://pixelvault.dev/docs) | Agent-first image hosting on Cloudflare's edge. Free tier: 200 MB storage, 500 uploads/month, 1 GB bandwidth/month, 5 MB max file size. REST API + OpenAPI 3.1 spec, instant CDN URLs. | **N/A** |
 | [**SignNow API – eSign API by airSlate**](https://docs.signnow.com/docs/signnow/welcome) | Embed branded eSignature workflows in your app and quickly customize them to your user needs. | 💸 |
 | [**Smash**](https://api.fromsmash.com/) | Smash API & SDK to upload large files on websites, mobile apps, SaaS solutions and custom workflows. | 💸 |
 | [**Vector Express**](https://github.com/smidyo/vectorexpress-api) | API for converting, processing and analyzing vector files.| **N/A** |


### PR DESCRIPTION
Adds PixelVault — agent-first image hosting (REST API + OpenAPI 3.1 spec), free tier, apiKey auth. Placed alphabetically between PDF Blocks and SignNow; Open/Trial marked N/A (free tier).